### PR TITLE
Cannot escape input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,8 @@ Changelog
 
 ### Unreleased
 - Update moustrap library to v1.6.5.
-- Fix isolation from default website actions in normal mode [#1](https://github.com/nbelzer/vimari/issues/1).
+- Fix isolation from default website actions in normal mode [nbelzer/#1](https://github.com/nbelzer/vimari/issues/1).
+- Add temporary solution for non-blurrable elements [nbelzer/#3](https://github.com/nbelzer/vimari/issues/3)
 
 ### 2.0.3 (2019-09-26)
 

--- a/Vimari Extension/js/injected.js
+++ b/Vimari Extension/js/injected.js
@@ -167,6 +167,12 @@ function unbindKeyCodes() {
  */
 function stopSitePropagation() {
 	return function (e) {
+        if (isActiveElementEditable() && e.keyIdentifier == "U+001B") {
+            // If we are inside an active element, pressing escape
+            // should blur it.  However as this does not always happen
+            // in Safari we can force the element to blur.
+            e.srcElement.blur()
+        }
 		if (insertMode === false && !isActiveElementEditable()) {
 			e.stopPropagation()
 		}

--- a/Vimari Extension/js/injected.js
+++ b/Vimari Extension/js/injected.js
@@ -167,10 +167,10 @@ function unbindKeyCodes() {
  */
 function stopSitePropagation() {
 	return function (e) {
-        if (isActiveElementEditable() && e.keyIdentifier == "U+001B") {
+        if (e.key == "Escape") {
             // If we are inside an active element, pressing escape
-            // should blur it.  However as this does not always happen
-            // in Safari we can force the element to blur.
+            // should blur it.  However as this is not the default
+            // behaviour in Safari we use this custom function
             e.srcElement.blur()
         }
 		if (insertMode === false && !isActiveElementEditable()) {


### PR DESCRIPTION
Resolves #3 

- Implements a temporary solution for non-escapable input elements which could get Vimari users stuck in for example an input element.
  _This is related to Safari not blurring these elements on escape by default (at least on the machines I was able to test)._